### PR TITLE
make file input field visible

### DIFF
--- a/private/css/style.css
+++ b/private/css/style.css
@@ -102,10 +102,6 @@ body {
     top: 1px;
 }
 
-input[type="file"] {
-    display: none;
-}
-
 .custom-file-upload {
     padding: 10px 5px;
     width: 140px;


### PR DESCRIPTION
i've just removed the style in question
it does not seem to be used anywhere else and is not in the original source files.

this is how it now looks in chrome:
![image](https://github.com/Carve/qbittorrent-webui-cjratliff.com/assets/22171518/ed831aec-09f8-41df-bc64-25bc27f1d0cd)
and firefox:
![image](https://github.com/Carve/qbittorrent-webui-cjratliff.com/assets/22171518/4dad9a87-d4c1-4a52-ae25-544b850b1c45)
