### PR TITLE
Displayed text has an extra bracket in .torrent upload popup

### DIFF
--- a/private/upload.html
+++ b/private/upload.html
@@ -144,7 +144,7 @@
                 </tr>
             </table>
             <div id="submitbutton" style="margin-top: 30px; text-align: center;">
-                <button class="download" id="button" type="submit"</button>
+                <button class="download" id="button" type="submit"></button>
             </div>
         </fieldset>
     </form>

--- a/private/upload.html
+++ b/private/upload.html
@@ -21,12 +21,12 @@
             <table style="margin: auto;">
                 <tr>
                     <td>
-                        <label for="autoTMM">(Torrent Management Mode:</label>
+                        <label for="autoTMM">Torrent Management Mode:</label>
                     </td>
                     <td>
                         <select id="autoTMM" name="autoTMM" onchange="qBittorrent.Download.changeTMM(this)">
-                            <option selected value="false">(Manual</option>
-                            <option value="true">(Automatic</option>
+                            <option selected value="false">Manual</option>
+                            <option value="true">Automatic</option>
                         </select>
                     </td>
                 </tr>
@@ -70,7 +70,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="addToTopOfQueue">(Add to top of queue</label>
+                        <label for="addToTopOfQueue">Add to top of queue</label>
                     </td>
                     <td>
                         <input type="checkbox" id="addToTopOfQueue" name="addToTopOfQueue" value="true" />
@@ -78,7 +78,7 @@
                 </tr>
                 <tr>
                     <td>
-                        <label for="stopCondition">(Stop condition:</label>
+                        <label for="stopCondition">Stop condition:</label>
                     </td>
                     <td>
                         <select id="stopCondition" name="stopCondition">


### PR DESCRIPTION
Just started using the theme and have noticed that in the popup for adding .torrent files to the client, there's a bunch of text with a `(` bracket at the beginning. While fixing that I have noticed a missing `>` arrow for the submit button and have included that as well in a separate commit.