### PR TITLE
Fix Ratio Limit column

### DIFF
--- a/private/scripts/dynamicTable.js
+++ b/private/scripts/dynamicTable.js
@@ -1309,7 +1309,12 @@ window.qBittorrent.DynamicTable = (function() {
             this.columns['completed'].updateTd = this.columns['size'].updateTd;
 
             // max_ratio
-            this.columns['max_ratio'].updateTd = this.columns['ratio'].updateTd;
+            this.columns['max_ratio'].updateTd = function(td, row) {
+                const max_ratio = this.getRowValue(row);
+                const string = (max_ratio === -1) ? '∞' : window.qBittorrent.Misc.toFixedPointString(max_ratio, 2);
+                td.set('text', string);
+                td.set('title', string);
+            };
 
             // seen_complete
             this.columns['seen_complete'].updateTd = this.columns['completion_on'].updateTd;


### PR DESCRIPTION
The Ratio Limit column parameters has been copied over from the Ratio column which cause that the Ratio Limit column had 'class=ratio'. Due to this the value of the hidden Ratio Limit column has been show in the next visible column instead of the column's real value.

This PR is fixing issue https://github.com/Carve/qbittorrent-webui-cjratliff.com/issues/49

Tested with qBt 4.6.3 and Safari and Firefox