### PR TITLE
Fix Add Tags input field missing defined value

### DIFF
--- a/private/views/rssDownloader.html
+++ b/private/views/rssDownloader.html
@@ -736,8 +736,8 @@ Supports the formats: S01E01, 1x1, 2017.12.31 and 31.12.2017 (Date formats also 
                 $('mustNotContainText').value = rulesList[ruleName].mustNotContain;
                 $('episodeFilterText').value = rulesList[ruleName].episodeFilter;
                 $('useSmartFilter').checked = rulesList[ruleName].smartFilter;
-
                 $('assignCategoryCombobox').value = rulesList[ruleName].assignedCategory ? rulesList[ruleName].assignedCategory : 'default';
+                $('ruleAddTags').value = rulesList[ruleName].torrentParams.tags;
                 $('savetoDifferentDir').checked = rulesList[ruleName].savePath !== '';
                 $('saveToText').value = rulesList[ruleName].savePath;
                 $('ignoreDaysValue').value = rulesList[ruleName].ignoreDays;


### PR DESCRIPTION
Added the missing line to load predefined value for Add Tags when an RSS downloader rule is loaded.

This PR is to fix issue https://github.com/Carve/qbittorrent-webui-cjratliff.com/issues/55

Tested with qBt 4.6.3, Safari and Firefox.